### PR TITLE
Add `onScriptLoaded` feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ const setting = {
 };
 
 const App = () => {
-  return <Zendesk zendeskKey={ZENDESK_KEY} {...setting} />;
+  return <Zendesk zendeskKey={ZENDESK_KEY} {...setting} onLoaded={() => console.log('is loaded')} />;
 };
 
 ReactDOM.render(<App />, document.getElementById("#app"));

--- a/src/index.js
+++ b/src/index.js
@@ -17,20 +17,28 @@ export const ZendeskAPI = (...args) => {
   }
 
 export default class Zendesk extends Component {
-    
+
     constructor(props) {
         super(props)
         this.insertScript = this.insertScript.bind(this)
+        this.onScriptLoaded = this.onScriptLoaded.bind(this)
       }
-    
+
+      onScriptLoaded() {
+        if (typeof this.props.onLoaded === 'function') {
+          this.props.onLoaded();
+        }
+      }
+
       insertScript (zendeskKey) {
         const script = document.createElement('script')
         script.async = true
         script.id = 'ze-snippet'
         script.src = `https://static.zdassets.com/ekr/snippet.js?key=${zendeskKey}`
+        script.addEventListener('load', this.onScriptLoaded);
         document.body.appendChild(script)
       }
-    
+
       componentDidMount() {
         if (canUseDOM && !window.zE) {
           const {zendeskKey, ...other} = this.props
@@ -55,5 +63,3 @@ export default class Zendesk extends Component {
 Zendesk.propTypes = {
     zendeskKey: PropTypes.string.isRequired
 }
-
-    


### PR DESCRIPTION
I added an `onScriptLoaded` feature to properly set Zendesk commands/events after the api has loaded. I ran into a race condition where Zendesk wasn't initialized yet. This makes sure that doesn't happen!

Example:
```
export default class LiveChat extends React.PureComponent {
  constructor(props) {
    super(props);

    this.onZendeskLoaded = this.onZendeskLoaded.bind(this);
  }

  onZendeskLoaded() {
    this.setZendeskCommands();
  }

  setZendeskCommands() {
    ZendeskAPI('webWidget:on', 'open', () => {
      console.log('widget is open');
    });
  }

  render() {
    const { zendeskKey } = this.props;

    return (
      <Zendesk zendeskKey={zendeskKey} onLoaded={() => this.onZendeskLoaded()} />
    );
  }
}
```