### PR TITLE
Fix invalid prop type warning on defer prop.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -66,5 +66,5 @@ export default class Zendesk extends Component {
 
 Zendesk.propTypes = {
     zendeskKey: PropTypes.string.isRequired,
-    defer: PropTypes.boolean
+    defer: PropTypes.bool
 }


### PR DESCRIPTION
PropTypes provides .bool rather than .boolean. This lead to undefined
being assigned to defer, rather than a function to check for bool.