### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
   "dependencies": {
     "prop-types": "^15.7.2"
   },
+  "peerDependencies": {
+    "react": ">=17.0.0"
+  },
   "devDependencies": {
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.9.0",


### PR DESCRIPTION
Higher level libraries that depend on package.json to resolve dependencies to build dependency graphs such as Bazel will fail in their attempts to resolve react as react is not an explicitly stated dependency in the package.json. This solves for this in a correct manner, if you want to add it any other way that also works.

Add missing peer dependency of react for semantic correctness.