### PR TITLE
Update insertScript to remove older script before add new script

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,10 @@ export default class Zendesk extends Component {
       }
 
       insertScript (zendeskKey, defer) {
+        const wasCreate = document.getElementById('ze-snippet')
+        if(wasCreate !== null){
+          wasCreate.remove()
+        }
         const script = document.createElement('script')
         if (defer) {
           script.defer = true


### PR DESCRIPTION
* this patch, its because if the script was creating in a react app before user is login, them when the user is into the app the script insertion will be duplicate.